### PR TITLE
Improve error responses for login and account creation endpoints

### DIFF
--- a/lib/ptolemy/controllers/auth/create.ex
+++ b/lib/ptolemy/controllers/auth/create.ex
@@ -3,7 +3,7 @@ defmodule Ptolemy.Controllers.Auth.Create do
 
   import Logger
   import Ptolemy.Helpers.Validators, only: [validate_body_params: 2]
-  import Ptolemy.Helpers.Responses
+  alias Ptolemy.Helpers.Responses, as: Resp
 
   alias Ptolemy.Schemas.User, as: User
   alias Ptolemy.Schemas.VerificationCode, as: VerificationCode
@@ -39,19 +39,19 @@ defmodule Ptolemy.Controllers.Auth.Create do
       if Application.get_env(:ptolemy, :enable_mailer) == "true" do
         case send_verification_email(user, verification_code) do
           :ok -> debug("Email sent successfully")
-          {:error, msg} -> error(msg)
+          {:error, msg} -> Resp.error(msg)
         end
       else
         debug("Verification code for email: #{user.email} is #{verification_code}")
       end
 
-      send_resp(conn, 201, information("Created"))
+      send_resp(conn, 201, Resp.information("Created"))
     else
       {:error, changeset} ->
         error_list = reformat_errors_for_json(changeset.errors)
 
         Plug.Conn.put_resp_header(conn, "content-type", "application/json")
-        |> send_resp(422, information("Unprocessable Entity", error_list))
+        |> send_resp(422, Resp.information("Unprocessable Entity", error_list))
     end
   end
 

--- a/lib/ptolemy/helpers/responses.ex
+++ b/lib/ptolemy/helpers/responses.ex
@@ -1,16 +1,26 @@
 defmodule Ptolemy.Helpers.Responses do
+  @spec information(String.t(), list(String.t())) :: binary
   def information(message, details) do
-    {:ok, json_string} =
-      Jason.encode(%{
-        message: message,
-        details: details
-      })
-
-    json_string
+    Jason.encode!(%{
+      message: message,
+      details: details
+    })
   end
 
   def information(message) do
     information(message, [])
+  end
+
+  @spec error(String.t(), map()) :: binary
+  def error(kind, details) do
+    Jason.encode!(%{
+      kind: kind,
+      details: details
+    })
+  end
+
+  def error(kind) do
+    error(kind, %{})
   end
 
   def data(message, data) do

--- a/spec/ptolemy.raml
+++ b/spec/ptolemy.raml
@@ -105,13 +105,11 @@ version: v1
           description: Authentication failed
           body:
             application/json:
-              type: Info
-              example:
-                message: Unauthorized
-                details: [Username or password is incorrect]
+              type: InvalidCredentials | UnverifiedEmail
     
 types:
   Info:
+    type: object
     description: |
       An informational response. The `message` property is a status message
       that should correspond to the HTTP status code's default message. The
@@ -120,3 +118,23 @@ types:
     properties:
       message: string
       details: string[]
+  Error:
+    type: object
+    discriminator: kind
+    description: |
+      Used to differentiate between various application level errors. The `kind`
+      property is used to discriminate between variants, and the `details`
+      property MAY contain additional information. By default, it will be an
+      empty object.
+    properties:
+      kind: string
+      details:
+        type: object
+        default: {}
+  InvalidCredentials:
+    type: Error 
+    description: |
+      The username provided does not exist, or the provided password is incorrect
+  UnverifiedEmail:
+    type: Error 
+    description: The user attempted to log in without verifying their email.

--- a/spec/ptolemy.raml
+++ b/spec/ptolemy.raml
@@ -34,10 +34,7 @@ version: v1
             account details.
           body:
             application/json:
-              type: Info
-              example:
-                message: Unprocessable Entity
-                details: [TODO]
+              type: DuplicateFields
   /verify:
     post:
       description: Verify the email for a user account
@@ -138,3 +135,21 @@ types:
   UnverifiedEmail:
     type: Error 
     description: The user attempted to log in without verifying their email.
+  DuplicateFields:
+    type: Error
+    description: |
+      The user tried to create an account but provided an email or username that
+      is already in use. The `details.fields` property contains an array of all
+      fields that are duplicated.
+    properties:
+      kind: string
+      details:
+        type: object
+        properties:
+          fields: string[]
+    example:
+      kind: DuplicateFields
+      details: {
+        fields: [email]
+      }
+

--- a/spec/serve_docs.sh
+++ b/spec/serve_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-raml2html ptolemy.raml > ptolemy.html
+raml2html -v ptolemy.raml > ptolemy.html
 
 python3 -m http.server 9000 &
 
@@ -15,7 +15,7 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 inotifywait -e close_write,moved_to,create -m . |
 while read -r directory events filename; do
   if [ "$filename" = "ptolemy.raml" ]; then
-    raml2html ptolemy.raml > ptolemy.html
+    raml2html -v ptolemy.raml > ptolemy.html
   fi
 done
 

--- a/test/ptolemy/controllers/auth/create_test.exs
+++ b/test/ptolemy/controllers/auth/create_test.exs
@@ -88,8 +88,12 @@ defmodule Ptolemy.Controllers.Auth.CreateTest do
 
     assert conn.state == :sent
     assert conn.status == 422
-    assert conn.resp_body == "{\"details\":[\"email has the following error: has already been taken\"],\"message\":\"Unprocessable Entity\"}"
+    parsed_body = Jason.decode!(conn.resp_body)
+    assert parsed_body["kind"] == "DuplicateFields"
+    assert match?(["email"], parsed_body["details"]["fields"])
 
+    # here we're just checking that the other user was created properly
+    # and not affected by the other account creation (no extra VC, for ex)
     new_user = Repo.get_by!(User, email: "test@example.com")
     assert new_user.email_verification_status == "pending"
 
@@ -114,8 +118,11 @@ defmodule Ptolemy.Controllers.Auth.CreateTest do
 
     assert conn.state == :sent
     assert conn.status == 422
-    assert conn.resp_body == "{\"details\":[\"username has the following error: has already been taken\"],\"message\":\"Unprocessable Entity\"}"
+    parsed_body = Jason.decode!(conn.resp_body)
+    assert parsed_body["kind"] == "DuplicateFields"
+    assert match?(["username"], parsed_body["details"]["fields"])
 
+    # Again, just checking the user is still set up right.
     new_user = Repo.get_by!(User, email: "test@example.com")
     assert new_user.email_verification_status == "pending"
 

--- a/test/support/auth_helpers.ex
+++ b/test/support/auth_helpers.ex
@@ -1,6 +1,8 @@
 defmodule Ptolemy.AuthHelpers do
   use Plug.Test
 
+  alias Ptolemy.Controllers.Auth.Verify
+  alias Ptolemy.Schemas.VerificationCode
   alias Ptolemy.Controllers.Auth.Create
 
   @spec create_user(String.t(), String.t(), String.t()) :: Plug.Conn.t()
@@ -23,6 +25,30 @@ defmodule Ptolemy.AuthHelpers do
       |> conn("/auth/create", request_body)
       |> put_req_header("content-type", "application/json")
       |> Create.call(opts)
+
+    conn
+  end
+
+  @spec verify_email(String.t()) :: Plug.Conn.t()
+  @doc """
+  Attempts to verify the provided email by searching the database for
+  a verification code, and sending a request to /auth/verify. If no
+  code is found, the `code` parameter of the verify endpoint is set
+  to an empty string, causing the request to fail.
+  """
+  def verify_email(email) do
+    maybe_code = case Ptolemy.Repo.get_by(VerificationCode, email: email) do
+      nil -> ""
+      vc -> vc.code
+    end
+
+    opts = Verify.init([])
+
+    conn =
+      :post
+      |> conn("/auth/verify?email=#{email}&code=#{maybe_code}")
+      |> put_req_header("content-type", "application/json")
+      |> Verify.call(opts)
 
     conn
   end


### PR DESCRIPTION
This PR introduces a new standard error response, and applies it to the `login` and `create` endpoints.

The new error response looks like this (using TypeScript here in the PR since it's easy for me to write):
```typescript
interface Error {
  kind: string;
  details: Record<string, unknown> | Record<string, never>;
}
```
The `kind` property is a discriminant that the frontend can use to quickly determine what kind of application-level error occurred. Each kind of error may use the `details` property to embed extra useful information. For example, the account creation endpoint uses the `details` property to embed a list of fields that are duplicate:
```typescript
interface DuplicateFields {
  kind: 'DuplicateFields';
  details: {
    fields: string[]
  }
}
```

Tests and RAML spec were updated accordingly.

Closes #8, closes #9