### PR TITLE
Login cleanup

### DIFF
--- a/lib/ptolemy/controllers/auth/create.ex
+++ b/lib/ptolemy/controllers/auth/create.ex
@@ -85,7 +85,7 @@ defmodule Ptolemy.Controllers.Auth.Create do
     encoded_query_params = URI.encode_query(query_params)
 
     html_body =
-      "Please verify your email by visiting the following link: <a href=\"http://localhost:4001?#{encoded_query_params}\">Click to verify</a>"
+      "Please verify your email by visiting the following link: <a href=\"http://localhost:3000/verify?#{encoded_query_params}\">Click to verify</a>"
 
     recipients = [
       %{

--- a/lib/ptolemy/controllers/auth/create.ex
+++ b/lib/ptolemy/controllers/auth/create.ex
@@ -42,7 +42,12 @@ defmodule Ptolemy.Controllers.Auth.Create do
           {:error, msg} -> Resp.error(msg)
         end
       else
-        debug("Verification code for email: #{user.email} is #{verification_code}")
+        query_params = %{"email" => user.email, "code" => verification_code}
+        encoded_query_params = URI.encode_query(query_params)
+
+        verification_url =
+          "http://localhost:3000/verify?#{encoded_query_params}"
+        debug("Verification link: #{verification_url}")
       end
 
       send_resp(conn, 201, Resp.information("Created"))

--- a/lib/ptolemy/controllers/auth/create.ex
+++ b/lib/ptolemy/controllers/auth/create.ex
@@ -3,7 +3,7 @@ defmodule Ptolemy.Controllers.Auth.Create do
 
   import Logger
   import Ptolemy.Helpers.Validators, only: [validate_body_params: 2]
-  import Ptolemy.Helpers.Responses
+  alias Ptolemy.Helpers.Responses, as: Resp
 
   alias Ptolemy.Schemas.User, as: User
   alias Ptolemy.Schemas.VerificationCode, as: VerificationCode
@@ -39,19 +39,19 @@ defmodule Ptolemy.Controllers.Auth.Create do
       if Application.get_env(:ptolemy, :enable_mailer) == "true" do
         case send_verification_email(user, verification_code) do
           :ok -> debug("Email sent successfully")
-          {:error, msg} -> error(msg)
+          {:error, msg} -> Resp.error(msg)
         end
       else
         debug("Verification code for email: #{user.email} is #{verification_code}")
       end
 
-      send_resp(conn, 201, information("Created"))
+      send_resp(conn, 201, Resp.information("Created"))
     else
       {:error, changeset} ->
         error_list = reformat_errors_for_json(changeset.errors)
 
         Plug.Conn.put_resp_header(conn, "content-type", "application/json")
-        |> send_resp(422, information("Unprocessable Entity", error_list))
+        |> send_resp(422, Resp.information("Unprocessable Entity", error_list))
     end
   end
 

--- a/lib/ptolemy/helpers/responses.ex
+++ b/lib/ptolemy/helpers/responses.ex
@@ -1,16 +1,26 @@
 defmodule Ptolemy.Helpers.Responses do
+  @spec information(String.t(), list(String.t())) :: binary
   def information(message, details) do
-    {:ok, json_string} =
-      Jason.encode(%{
-        message: message,
-        details: details
-      })
-
-    json_string
+    Jason.encode!(%{
+      message: message,
+      details: details
+    })
   end
 
   def information(message) do
     information(message, [])
+  end
+
+  @spec error(String.t(), map()) :: binary
+  def error(kind, details) do
+    Jason.encode!(%{
+      kind: kind,
+      details: details
+    })
+  end
+
+  def error(kind) do
+    error(kind, %{})
   end
 
   def data(message, data) do

--- a/lib/ptolemy/root_router.ex
+++ b/lib/ptolemy/root_router.ex
@@ -19,7 +19,13 @@ defmodule Ptolemy.RootRouter do
     signing_salt: Application.compile_env(:ptolemy, :signing_salt),
     log: :debug
   )
+  # For now, only configure CORS to accept requests from my local WebPack
+  # server. A production deployment will make this more complicated, but
+  # we can keep it simple for now.
+  plug(CORSPlug, origin: ["http://localhost:3000"])
 
+  # The order of the plugs here is important because we need CORSPlug
+  # to intercept OPTIONS requests, which are otherwise undefined.
   plug(:match)
   plug(:dispatch)
 
@@ -28,6 +34,7 @@ defmodule Ptolemy.RootRouter do
   end
 
   use Plug.ErrorHandler
+
 
   forward("/auth", to: Ptolemy.Routes.Auth)
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Ptolemy.MixProject do
     [
       {:plug, "~> 1.13"},
       {:plug_cowboy, "~> 2.0"},
+      {:cors_plug, "~> 3.0"},
       {:ecto_sql, "~> 3.0"},
       {:postgrex, ">= 0.0.0"},
       {:jason, "~> 1.4"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
+  "cors_plug": {:hex, :cors_plug, "3.0.3", "7c3ac52b39624bc616db2e937c282f3f623f25f8d550068b6710e58d04a0e330", [:mix], [{:plug, "~> 1.13", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "3f2d759e8c272ed3835fab2ef11b46bddab8c1ab9528167bd463b6452edf830d"},
   "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},
   "cowboy_telemetry": {:hex, :cowboy_telemetry, "0.4.0", "f239f68b588efa7707abce16a84d0d2acf3a0f50571f8bb7f56a15865aae820c", [:rebar3], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7d98bac1ee4565d31b62d59f8823dfd8356a169e7fcbb83831b8a5397404c9de"},
   "cowlib": {:hex, :cowlib, "2.11.0", "0b9ff9c346629256c42ebe1eeb769a83c6cb771a6ee5960bd110ab0b9b872063", [:make, :rebar3], [], "hexpm", "2b3e9da0b21c4565751a6d4901c20d1b4cc25cbb7fd50d91d2ab6dd287bc86a9"},

--- a/spec/ptolemy.raml
+++ b/spec/ptolemy.raml
@@ -105,13 +105,11 @@ version: v1
           description: Authentication failed
           body:
             application/json:
-              type: Info
-              example:
-                message: Unauthorized
-                details: [Username or password is incorrect]
+              type: InvalidCredentials | UnverifiedEmail
     
 types:
   Info:
+    type: object
     description: |
       An informational response. The `message` property is a status message
       that should correspond to the HTTP status code's default message. The
@@ -120,3 +118,23 @@ types:
     properties:
       message: string
       details: string[]
+  Error:
+    type: object
+    discriminator: kind
+    description: |
+      Used to differentiate between various application level errors. The `kind`
+      property is used to discriminate between variants, and the `details`
+      property MAY contain additional information. By default, it will be an
+      empty object.
+    properties:
+      kind: string
+      details:
+        type: object
+        default: {}
+  InvalidCredentials:
+    type: Error 
+    description: |
+      The username provided does not exist, or the provided password is incorrect
+  UnverifiedEmail:
+    type: Error 
+    description: The user attempted to log in without verifying their email.

--- a/spec/ptolemy.raml
+++ b/spec/ptolemy.raml
@@ -34,10 +34,7 @@ version: v1
             account details.
           body:
             application/json:
-              type: Info
-              example:
-                message: Unprocessable Entity
-                details: [TODO]
+              type: DuplicateFields
   /verify:
     post:
       description: Verify the email for a user account
@@ -138,3 +135,21 @@ types:
   UnverifiedEmail:
     type: Error 
     description: The user attempted to log in without verifying their email.
+  DuplicateFields:
+    type: Error
+    description: |
+      The user tried to create an account but provided an email or username that
+      is already in use. The `details.fields` property contains an array of all
+      fields that are duplicated.
+    properties:
+      kind: string
+      details:
+        type: object
+        properties:
+          fields: string[]
+    example:
+      kind: DuplicateFields
+      details: {
+        fields: [email]
+      }
+

--- a/spec/serve_docs.sh
+++ b/spec/serve_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-raml2html ptolemy.raml > ptolemy.html
+raml2html -v ptolemy.raml > ptolemy.html
 
 python3 -m http.server 9000 &
 
@@ -15,7 +15,7 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 inotifywait -e close_write,moved_to,create -m . |
 while read -r directory events filename; do
   if [ "$filename" = "ptolemy.raml" ]; then
-    raml2html ptolemy.raml > ptolemy.html
+    raml2html -v ptolemy.raml > ptolemy.html
   fi
 done
 

--- a/test/ptolemy/controllers/auth/create_test.exs
+++ b/test/ptolemy/controllers/auth/create_test.exs
@@ -88,8 +88,12 @@ defmodule Ptolemy.Controllers.Auth.CreateTest do
 
     assert conn.state == :sent
     assert conn.status == 422
-    assert conn.resp_body == "{\"details\":[\"email has the following error: has already been taken\"],\"message\":\"Unprocessable Entity\"}"
+    parsed_body = Jason.decode!(conn.resp_body)
+    assert parsed_body["kind"] == "DuplicateFields"
+    assert match?(["email"], parsed_body["details"]["fields"])
 
+    # here we're just checking that the other user was created properly
+    # and not affected by the other account creation (no extra VC, for ex)
     new_user = Repo.get_by!(User, email: "test@example.com")
     assert new_user.email_verification_status == "pending"
 
@@ -114,8 +118,11 @@ defmodule Ptolemy.Controllers.Auth.CreateTest do
 
     assert conn.state == :sent
     assert conn.status == 422
-    assert conn.resp_body == "{\"details\":[\"username has the following error: has already been taken\"],\"message\":\"Unprocessable Entity\"}"
+    parsed_body = Jason.decode!(conn.resp_body)
+    assert parsed_body["kind"] == "DuplicateFields"
+    assert match?(["username"], parsed_body["details"]["fields"])
 
+    # Again, just checking the user is still set up right.
     new_user = Repo.get_by!(User, email: "test@example.com")
     assert new_user.email_verification_status == "pending"
 

--- a/test/support/auth_helpers.ex
+++ b/test/support/auth_helpers.ex
@@ -1,6 +1,8 @@
 defmodule Ptolemy.AuthHelpers do
   use Plug.Test
 
+  alias Ptolemy.Controllers.Auth.Verify
+  alias Ptolemy.Schemas.VerificationCode
   alias Ptolemy.Controllers.Auth.Create
 
   @spec create_user(String.t(), String.t(), String.t()) :: Plug.Conn.t()
@@ -23,6 +25,30 @@ defmodule Ptolemy.AuthHelpers do
       |> conn("/auth/create", request_body)
       |> put_req_header("content-type", "application/json")
       |> Create.call(opts)
+
+    conn
+  end
+
+  @spec verify_email(String.t()) :: Plug.Conn.t()
+  @doc """
+  Attempts to verify the provided email by searching the database for
+  a verification code, and sending a request to /auth/verify. If no
+  code is found, the `code` parameter of the verify endpoint is set
+  to an empty string, causing the request to fail.
+  """
+  def verify_email(email) do
+    maybe_code = case Ptolemy.Repo.get_by(VerificationCode, email: email) do
+      nil -> ""
+      vc -> vc.code
+    end
+
+    opts = Verify.init([])
+
+    conn =
+      :post
+      |> conn("/auth/verify?email=#{email}&code=#{maybe_code}")
+      |> put_req_header("content-type", "application/json")
+      |> Verify.call(opts)
 
     conn
   end


### PR DESCRIPTION
This PR includes some cleanup details that were necessary for https://github.com/JDSeiler/alexandria/issues/2

- You can no longer log in if your email is unverified
- Added error responses to the account creation and login endpoints that are easier to handle on the frontend
- Updated the RAML spec
- Added a CORS plug so that I don't need to mess with a proxy
- Plus other misc. tidbits, nothing major.